### PR TITLE
ClassesController上でのclasses_detailのデータの取り出し方を修正

### DIFF
--- a/app/Http/Controllers/ClassesController.php
+++ b/app/Http/Controllers/ClassesController.php
@@ -68,7 +68,7 @@ class ClassesController extends Controller {
 		$data = array(
 			'review'  => $this->review->reviews($id),
 			'detail'  => $this->classes->find($id),
-			'detail_wpr' => $this->classes_detail->find($id),
+			'detail_wpr' => $this->classes_detail->where('class_id','=',$id)->first(),
 			'teacher' => $this->classes->find($id)->teachers,
 			'tag' 	  => array(
 					'list' 			 => $tag->returnTagNamesByClassId($id),


### PR DESCRIPTION
find($id)
ではなく、
where("class_id","=",$id)->first()
じゃないと、classesに紐づいたclasses_detailのデータを持って来れない
